### PR TITLE
Forward inherited members in generated draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /**/.DS_Store
 /**/*.draft.dart
+.vscode

--- a/packages/draft_builder/test/integration/subtyping.dart
+++ b/packages/draft_builder/test/integration/subtyping.dart
@@ -1,0 +1,39 @@
+import 'package:draft/draft.dart';
+
+part 'subtyping.draft.dart';
+
+sealed class Parent extends Base with Mixin implements Interface {
+  @override
+  bool get flagA => true;
+
+  @override
+  void methodA() {}
+}
+
+@draft
+class Child extends Parent {
+  Child({required this.value});
+
+  final int value;
+
+  @override
+  bool get flagB => false;
+
+  @override
+  void methodB() {}
+}
+
+abstract class Base {
+  bool get flagA;
+  void methodA();
+}
+
+abstract interface class Interface {
+  bool get flagA;
+  void methodB();
+}
+
+abstract mixin class Mixin {
+  bool get flagB;
+  void methodA();
+}

--- a/packages/draft_builder/test/subtyping_test.dart
+++ b/packages/draft_builder/test/subtyping_test.dart
@@ -1,0 +1,53 @@
+import 'package:test/test.dart';
+
+import 'common.dart';
+import 'integration/subtyping.dart';
+
+void main() {
+  test('compiles', () async {
+    await expectLater(
+      compile(r'''
+import 'subtyping.dart';
+
+void main() {
+  Child(value: 1);
+  Child(value: 1).draft().save();
+  Child(value: 1).draft().methodA();
+  Child(value: 1).draft().methodB();
+  bool a = Child(value: 1).draft().flagA;
+  bool b = Child(value: 1).draft().flagB;
+  Child(value: 1).produce((draft) {
+    draft.value = 2;
+    draft.methodA();
+    draft.methodB();
+    bool a1 = draft.flagA;
+    bool b1 = draft.flagB;
+  });
+  Child(value: 1).methodA();
+  Child(value: 1).methodB();
+  bool a2 = Child(value: 1).flagA;
+  bool b2 = Child(value: 1).flagB;
+}
+'''),
+      completes,
+    );
+  });
+
+  test('works correctly', () async {
+    final instance = Child(value: 1);
+    final draft = instance.draft();
+    expect(draft.value, 1);
+    draft.value = 2;
+    expect(draft.value, 2);
+    expect(instance.value, 1);
+    final saved = draft.save();
+    expect(saved.value, 2);
+    expect(instance.value, 1);
+    expect(saved, isNot(same(instance)));
+    expect(saved, isNot(same(draft)));
+    expect(saved.flagA, isTrue);
+    expect(saved.draft().flagA, isTrue);
+    expect(saved.flagB, isFalse);
+    expect(saved.draft().flagB, isFalse);
+  });
+}


### PR DESCRIPTION
Adds support for forwarding members inherited from super types in generated drafts.

Resolves #7.